### PR TITLE
spatialDraw uses world origin instead of groundplane + tool modelView

### DIFF
--- a/tools/spatialDraw/DrawingManager.js
+++ b/tools/spatialDraw/DrawingManager.js
@@ -584,7 +584,7 @@ DrawingManager.Tool.Line = class extends DrawingManager.Tool {
      * @param {Object} drawing - The serialized object defining the object to be drawn.
      */
     drawFromSerialized(parent, drawing) {
-        const meshLineMaterial = generateMeshLineMaterial(drawing.size, drawing.color, this.drawingManager.resolution);
+        const meshLineMaterial = generateMeshLineMaterial(drawing.size, drawing.color);
 
         const threePoints = drawing.points.map(point => new THREE.Vector3(point.x, point.y, point.z));
         const curve = new THREE.CatmullRomCurve3(threePoints);

--- a/tools/spatialDraw/DrawingManager.js
+++ b/tools/spatialDraw/DrawingManager.js
@@ -463,8 +463,10 @@ DrawingManager.Cursor = class {
      * @return {THREE.Vector3} - The position of the calculated point.
      */
     screenProject(pointerEvent, distance, camera, scene) {
-        const ray = this.getScreenRay(pointerEvent, camera);
-        return ray.origin.clone().add(ray.direction.clone().multiplyScalar(distance)).applyMatrix4(camera.matrixWorld).applyMatrix4(scene.matrixWorld.clone().invert());
+        const ray = this.getScreenRay(pointerEvent, camera); // world-space ray
+        const worldPoint = ray.origin.clone().add(ray.direction.clone().multiplyScalar(distance));
+        // To get the point in the local space of `scene` (e.g., mainContainerObj parent), invert it
+        return worldPoint.clone().applyMatrix4(scene.matrixWorld.clone().invert()); // <-- local point
     }
 };
 
@@ -582,7 +584,7 @@ DrawingManager.Tool.Line = class extends DrawingManager.Tool {
      * @param {Object} drawing - The serialized object defining the object to be drawn.
      */
     drawFromSerialized(parent, drawing) {
-        const meshLineMaterial = generateMeshLineMaterial(drawing.size, drawing.color);
+        const meshLineMaterial = generateMeshLineMaterial(drawing.size, drawing.color, this.drawingManager.resolution);
 
         const threePoints = drawing.points.map(point => new THREE.Vector3(point.x, point.y, point.z));
         const curve = new THREE.CatmullRomCurve3(threePoints);
@@ -799,7 +801,7 @@ DrawingManager.Cursor.Offset = class extends DrawingManager.Cursor {
      */
     constructor() {
         super();
-        this.offset = 500;
+        this.offset = 1000; // draw on a plane 1m away from the screen
         this.position = new THREE.Vector3(0, 0, 0);
     }
 

--- a/tools/spatialDraw/index.html
+++ b/tools/spatialDraw/index.html
@@ -2,7 +2,10 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    <title>Spatial Sensor</title>
+    <!-- Ensure the aspect ratio is calculated correctly on iOS -->
+    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+
+    <title>Spatial Draw</title>
     <script src="objectDefaultFiles/object.js"></script>
     <script src="objectDefaultFiles/envelope.js"></script>
     <script src="objectDefaultFiles/pep.min.js"></script>

--- a/tools/spatialDraw/index.js
+++ b/tools/spatialDraw/index.js
@@ -278,7 +278,6 @@ function initRenderer() {
 
             spatialInterface.changeFrameSize(mainData.width, mainData.height);
             spatialInterface.onWindowResized(({width, height}) => {
-                console.log('onWindowResized');
                 mainData.width = width;
                 mainData.height = height;
                 rendererWidth = width;
@@ -389,7 +388,6 @@ render = function(_now) {
         setMatrixFromArray(camera.projectionMatrix, lastProjectionMatrix);
         camera.projectionMatrixInverse.getInverse(camera.projectionMatrix);
         isProjectionMatrixSet = true;
-        console.log('setting new projectionMatrix', camera.projectionMatrix);
     }
 
     if (isProjectionMatrixSet && lastCameraMatrix && lastCameraMatrix.length === 16) {

--- a/tools/spatialDraw/index.js
+++ b/tools/spatialDraw/index.js
@@ -12,7 +12,6 @@ let lastSync = 0;
 let realRenderer, renderer;
 let camera, scene;
 let mainContainerObj;
-let groundPlaneContainerObj;
 let spatialInterface;
 
 let rendererWidth;
@@ -20,7 +19,7 @@ let rendererHeight;
 let aspectRatio;
 
 let lastProjectionMatrix = null;
-let lastModelViewMatrix = null;
+let lastCameraMatrix = null;
 let isProjectionMatrixSet = false;
 let done = false; // used by gl renderer
 
@@ -308,6 +307,7 @@ function initRenderer() {
 
             // create a threejs camera and scene
             camera = new THREE.PerspectiveCamera( 70, aspectRatio, 1, 1000 );
+            camera.matrixAutoUpdate = false;
             scene = new THREE.Scene();
             scene.add(camera);
 
@@ -319,25 +319,22 @@ function initRenderer() {
             mainContainerObj.name = 'mainContainerObj';
             scene.add(mainContainerObj);
 
-            groundPlaneContainerObj = new THREE.Object3D();
-            groundPlaneContainerObj.matrixAutoUpdate = false;
-            groundPlaneContainerObj.name = 'groundPlaneContainerObj';
-            scene.add(groundPlaneContainerObj);
-
             // light the scene with ambient light
             const ambLight = new THREE.AmbientLight(0x404040);
             scene.add(ambLight);
             const directionalLight = new THREE.DirectionalLight(0xFFFFFF);
             directionalLight.position.set(0, 100000, 0);
-            groundPlaneContainerObj.add(directionalLight);
+            mainContainerObj.add(directionalLight);
             const directionalLight2 = new THREE.DirectionalLight(0xFFFFFF);
             directionalLight2.position.set(100000, 0, 100000);
-            groundPlaneContainerObj.add(directionalLight2);
+            mainContainerObj.add(directionalLight2);
 
             spatialInterface.onSpatialInterfaceLoaded(function() {
-                spatialInterface.subscribeToMatrix();
-                spatialInterface.addGroundPlaneMatrixListener(groundPlaneCallback);
-                spatialInterface.addMatrixListener(updateMatrices); // whenever we receive new matrices from the editor, update the 3d scene
+                spatialInterface.subscribeToCoordinateSystems([
+                    spatialObject.COORDINATE_SYSTEMS.CAMERA,
+                    spatialObject.COORDINATE_SYSTEMS.WORLD_ORIGIN,
+                    spatialObject.COORDINATE_SYSTEMS.PROJECTION_MATRIX,
+                ], onCoordinateSystems);
                 spatialInterface.registerTouchDecider(touchDecider);
                 spatialInterface.getScreenDimensions((width, height) => {
                     adjustSidebarForWindowSize(height);
@@ -357,23 +354,31 @@ function touchDecider(eventData) {
     return appActive;
 }
 
-function setMatrixFromArray(matrix, array) {
-    matrix.set( array[0], array[4], array[8], array[12],
-        array[1], array[5], array[9], array[13],
-        array[2], array[6], array[10], array[14],
-        array[3], array[7], array[11], array[15]
+function setMatrixFromArray(matrix, rowMajorArray) {
+    matrix.set( rowMajorArray[0], rowMajorArray[4], rowMajorArray[8], rowMajorArray[12],
+        rowMajorArray[1], rowMajorArray[5], rowMajorArray[9], rowMajorArray[13],
+        rowMajorArray[2], rowMajorArray[6], rowMajorArray[10], rowMajorArray[14],
+        rowMajorArray[3], rowMajorArray[7], rowMajorArray[11], rowMajorArray[15]
     );
 }
 
-function groundPlaneCallback(modelViewMatrix) {
-    setMatrixFromArray(groundPlaneContainerObj.matrix, modelViewMatrix);
-    mainContainerObj.groundPlaneContainerObj = groundPlaneContainerObj;
-}
+/**
+ * Handler for spatialInterface.subscribeToCoordinateSystems
+ * @param {Object} updatedSystems
+ */
+function onCoordinateSystems(updatedSystems) {
+    if (updatedSystems[spatialObject.COORDINATE_SYSTEMS.PROJECTION_MATRIX]) {
+        lastProjectionMatrix = updatedSystems[spatialObject.COORDINATE_SYSTEMS.PROJECTION_MATRIX];
+    }
 
+    if (updatedSystems[spatialObject.COORDINATE_SYSTEMS.WORLD_ORIGIN]) {
+        setMatrixFromArray(mainContainerObj.matrix, updatedSystems[spatialObject.COORDINATE_SYSTEMS.WORLD_ORIGIN]);
+        mainContainerObj.updateMatrixWorld(true);
+    }
 
-function updateMatrices(modelViewMatrix, projectionMatrix) {
-    lastProjectionMatrix = projectionMatrix;
-    lastModelViewMatrix = modelViewMatrix;
+    if (updatedSystems[spatialObject.COORDINATE_SYSTEMS.CAMERA]) {
+        lastCameraMatrix = updatedSystems[spatialObject.COORDINATE_SYSTEMS.CAMERA];
+    }
 }
 
 // Draw the scene repeatedly
@@ -384,14 +389,17 @@ render = function(_now) {
         setMatrixFromArray(camera.projectionMatrix, lastProjectionMatrix);
         camera.projectionMatrixInverse.getInverse(camera.projectionMatrix);
         isProjectionMatrixSet = true;
+        console.log('setting new projectionMatrix', camera.projectionMatrix);
     }
 
-    if (isProjectionMatrixSet && lastModelViewMatrix && lastModelViewMatrix.length === 16) {
-        // update model view matrix
-        setMatrixFromArray(mainContainerObj.matrix, lastModelViewMatrix);
-
+    if (isProjectionMatrixSet && lastCameraMatrix && lastCameraMatrix.length === 16) {
         // render the scene
         mainContainerObj.visible = true;
+
+        // manually update the camera's local/world/inverse matrices
+        setMatrixFromArray(camera.matrix, lastCameraMatrix);
+        camera.updateMatrixWorld(true);
+        camera.matrixWorldInverse.copy(camera.matrixWorld).invert();
 
         if (renderer && scene && camera) {
             drawingManager.triggerCallbacks('render', _now);


### PR DESCRIPTION
- The Vuforia groundplane tracker only activates if any tools are using it; the spatialDraw tool has been rendering lines relative to the tool origin and the groundplane, which is unnecessarily complicated and activates the extra tracker.
- This switches it to use the newer / more efficient coordinate system APIs, which includes a world origin, camera, and projection matrix.
- This also means you can now drag/scale the tool icon and the drawings won't move with it; they are fixed to the world.

Side effect of this change:
- Previously-drawn drawings will show up in the wrong position, since the points stored in the publicData are relative to the tool origin. I can write some migration logic if we want old drawings to still look good, it'll just undo some of the efficiencies because I'll have to subscribe to the other matrices to determine the relative transform.