### PR TITLE
get the mobileCanvasPixelRatio and use instead of window.devicePixelRatio on mobile, to reduce rendering overhead

### DIFF
--- a/tools/spatialDraw/index.js
+++ b/tools/spatialDraw/index.js
@@ -292,6 +292,7 @@ function initRenderer() {
 
             realRenderer = new THREE.WebGLRenderer( { alpha: true } );
             realRenderer.debug.checkShaderErrors = false;
+            // set the initial pixelRatio using the devicePixelRatio; overwrite later with getEnvironmentVariables
             realRenderer.setPixelRatio(window.devicePixelRatio);
             realRenderer.setSize(rendererWidth, rendererHeight);
             // eslint-disable-next-line no-global-assign
@@ -337,6 +338,11 @@ function initRenderer() {
                 spatialInterface.registerTouchDecider(touchDecider);
                 spatialInterface.getScreenDimensions((width, height) => {
                     adjustSidebarForWindowSize(height);
+                });
+                spatialInterface.getEnvironmentVariables().then((environmentVariables) => {
+                    if (!window.isDesktop() && typeof environmentVariables.mobileCanvasPixelRatio === 'number') {
+                        realRenderer.setPixelRatio(environmentVariables.mobileCanvasPixelRatio);
+                    }
                 });
                 resolve();
             });


### PR DESCRIPTION
Uses the environment variable from https://github.com/dataTimeSpace/vuforia-spatial-toolbox-userinterface/pull/131, so that the gl proxy renderer inside the spatialDraw tool uses the lower pixelRatio too.

The glcanvas in the parent already isn't scaled up by the devicePixelRatio, so I think this is wasted space. Safari web inspector shows the canvases allocated for each tool in addition to the composition glcanvas. With this code, each of the child canvases is only 430x932 (same as the composition canvas), rather than 3x the width and height.

Empirically I get better fps rates with these changes.

I can see this e.g. when I have two spatialDraw tools, one with a pink drawing and one with a yellow drawing (canvas 1, 6, and 7):
<img width="983" height="559" alt="Screenshot 2025-08-06 at 12 29 38 PM" src="https://github.com/user-attachments/assets/78d1e5f3-737d-42d4-86d6-0b2fbfa769c0" />
