### PR TITLE
set z-index of drawing tool to 10 when it opens, so the palette draws on top of other tools

### DIFF
--- a/tools/spatialDraw/index.js
+++ b/tools/spatialDraw/index.js
@@ -43,6 +43,8 @@ if (!spatialInterface) {
 spatialInterface.setMoveDelay(500);
 spatialInterface.useWebGlWorker();
 spatialInterface.setAlwaysFaceCamera(true);
+// set this to a positive number so that the UI gets layered on top of other tools when the envelope opens
+spatialObject.fullscreenZPosition = 10;
 
 spatialInterface.wasToolJustCreated(justCreated => {
     if (justCreated) {


### PR DESCRIPTION
I realized I can apply the same z-index trick to the other tools so their UI palettes show up in front.

<img width="108" height="291" alt="Screenshot 2025-08-06 at 3 34 03 PM" src="https://github.com/user-attachments/assets/db17abfe-fc73-4ef9-980d-a2dea9c5351a" />
